### PR TITLE
Prevent error when `Accept` header is not sent.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -64,7 +64,7 @@ proto.install = function(server) {
 
   function is_okay(req) {
     var is_okay = req.method === 'GET'
-      , accept = req.headers.accept
+      , accept = req.headers.accept || ''
 
     is_okay = is_okay && (!!~accept.indexOf('text/event-stream') || !!~accept.indexOf('text/x-dom-event-stream'))
 


### PR DESCRIPTION
It's not a common problem, but it was bringing the process down on every request to the server. Thanks!
