### PR TITLE
fix: cast to string before splitting data

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -8,7 +8,7 @@ function Client(req, res) {
   this.req = req
   this.res = res
 
-  this.legacy = req.headers['user-agent'] && false // (/^Opera/).test(req.headers['user-agent'])  
+  this.legacy = req.headers['user-agent'] && false // (/^Opera/).test(req.headers['user-agent'])
   this.writable = true
   this.readable = false
 
@@ -33,11 +33,11 @@ proto.retry = function(ms) {
 }
 
 proto.write = function(data) {
-  var response = 
+  var response =
       'id: '+(this._id++)+'\n\n'
     + (this.legacy ? 'Event: data\n' : '')
     + this.data_header
-    + data.split('\n').join('\n'+this.data_header)+'\n\n'
+    + String(data).split('\n').join('\n'+this.data_header)+'\n\n'
 
   return this.res.write(response)
 }


### PR DESCRIPTION
- fixes issue where this fails due to `data` pointing to a `Buffer` instead of string
  
  ```
  ~/sse-stream/lib/client.js:42
      + data.split('\n').join('\n'+this.data_header)+'\n\n'
             ^
  
  TypeError: data.split is not a function
      at Client.proto.write (~/sse-stream/lib/client.js:42:12)
      at PassThrough.ondata (~/readable-stream/lib/_stream_readable.js:543:20)
      at emitOne (events.js:96:13)
      at PassThrough.emit (events.js:188:7)
      at readableAddChunk (~/readable-stream/lib/_stream_readable.js:210:18)
      at PassThrough.Readable.push (~/readable-stream/lib/_stream_readable.js:169:10)
      at PassThrough.Transform.push (~/readable-stream/lib/_stream_transform.js:123:32)
      at Browserify.<anonymous> (~/bankai/handler-js.js:86:23)
      at emitOne (events.js:101:20)
      at Browserify.emit (events.js:188:7)
  ```
- isolated change contained in #2
